### PR TITLE
Only register non-abstract dependencies

### DIFF
--- a/src/CQRS.LightInject.Tests/InterceptorTests.cs
+++ b/src/CQRS.LightInject.Tests/InterceptorTests.cs
@@ -99,10 +99,10 @@ namespace CQRS.LightInject.Tests
             container.Register<IFoo, Foo>();
             bool invoked = false;
 
-            container.RegisterQueryInterceptor<SampleQuery, SampleQueryResult>(async (command, handler, token) =>
+            container.RegisterQueryInterceptor<SampleQuery, SampleQueryResult>(async (query, handler, token) =>
             {
                 invoked = true;
-                return await handler.HandleAsync(command, token);
+                return await handler.HandleAsync(query, token);
             }
             );
 
@@ -124,11 +124,11 @@ namespace CQRS.LightInject.Tests
             bool invoked = false;
             IFoo passedFoo = null;
 
-            container.RegisterQueryInterceptor<SampleQuery, SampleQueryResult, IFoo>(async (command, handler, foo, token) =>
+            container.RegisterQueryInterceptor<SampleQuery, SampleQueryResult, IFoo>(async (query, handler, foo, token) =>
             {
                 passedFoo = foo;
                 invoked = true;
-                return await handler.HandleAsync(command, token);
+                return await handler.HandleAsync(query, token);
             }
             );
 
@@ -153,12 +153,12 @@ namespace CQRS.LightInject.Tests
             IFoo passedFoo = null;
             IBar passedBar = null;
 
-            container.RegisterQueryInterceptor<SampleQuery, SampleQueryResult, (IFoo foo, IBar bar)>(async (command, handler, dependencies, token) =>
+            container.RegisterQueryInterceptor<SampleQuery, SampleQueryResult, (IFoo foo, IBar bar)>(async (query, handler, dependencies, token) =>
             {
                 passedFoo = dependencies.foo;
                 passedBar = dependencies.bar;
                 invoked = true;
-                return await handler.HandleAsync(command, token);
+                return await handler.HandleAsync(query, token);
             }
             );
 
@@ -171,6 +171,30 @@ namespace CQRS.LightInject.Tests
                 passedFoo.Should().BeOfType<Foo>();
                 passedBar.Should().BeOfType<Bar>();
             }
+        }
+
+        [Fact]
+        public void ShouldNotRegisterAbstractTypesForQueryInterceptors()
+        {
+            var container = new ServiceContainer();
+            container.RegisterQueryInterceptor<SampleQuery, SampleQueryResult, IFoo>(async (query, handler, dependency, token) =>
+            {
+                return await handler.HandleAsync(query, token);
+            });
+
+            container.AvailableServices.Should().NotContain(sr => sr.ServiceType == typeof(IFoo));
+        }
+
+        [Fact]
+        public void ShouldNotRegisterAbstractTypesForCommandnterceptors()
+        {
+            var container = new ServiceContainer();
+            container.RegisterCommandInterceptor<SampleCommand, IFoo>(async (command, handler, dependency, token) =>
+            {
+
+            });
+
+            container.AvailableServices.Should().NotContain(sr => sr.ServiceType == typeof(IFoo));
         }
     }
 }

--- a/src/CQRS.LightInject/CQRS.LightInject.csproj
+++ b/src/CQRS.LightInject/CQRS.LightInject.csproj
@@ -14,7 +14,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CQRS.Execution" Version="1.0.0" />

--- a/src/CQRS.LightInject/ServiceRegistryExtensions.cs
+++ b/src/CQRS.LightInject/ServiceRegistryExtensions.cs
@@ -1,7 +1,6 @@
 namespace CQRS.LightInject
 {
     using System;
-    using System.Linq;
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
@@ -113,7 +112,7 @@ namespace CQRS.LightInject
         /// <returns><see cref="IServiceRegistry"/>.</returns>
         public static IServiceRegistry RegisterCommandInterceptor<TCommand, TDependency>(this IServiceRegistry serviceRegistry, Func<TCommand, ICommandHandler<TCommand>, TDependency, CancellationToken, Task> implementation)
         {
-            if (!serviceRegistry.AvailableServices.Any(sr => sr.ServiceType == typeof(TDependency)))
+            if (!typeof(TDependency).IsAbstract)
             {
                 serviceRegistry.Register<TDependency>();
             }
@@ -145,7 +144,7 @@ namespace CQRS.LightInject
         public static IServiceRegistry RegisterQueryInterceptor<TQuery, TResult, TDependency>(this IServiceRegistry serviceRegistry, Func<TQuery, IQueryHandler<TQuery, TResult>, TDependency, CancellationToken, Task<TResult>> implementation)
            where TQuery : IQuery<TResult>
         {
-            if (!serviceRegistry.AvailableServices.Any(sr => sr.ServiceType == typeof(TDependency)))
+            if (!typeof(TDependency).IsAbstract)
             {
                 serviceRegistry.Register<TDependency>();
             }


### PR DESCRIPTION
This PR ensures that we only register `TDependency`if it is a concrete type.